### PR TITLE
Add zero allocation version of toRfc3339

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache
+.zig-cache
 zig-out

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ the supported schema in Dylibso's [XTP](https://getxtp.com) product.
 - Conversion from Unix timestamp (milliseconds)
 - Timezone offset support
 - RFC 3339 string formatting
+- zero allocations if desired
 
 ## Installation
 
@@ -35,7 +36,18 @@ pub fn main() !void {
     const dt = DateTime.fromMillis(std.time.milliTimestamp());
 
     // Directly convert to an RFC 3339 DateTime string
-    const s = try dt.toRfc3339(std.heap.wasm_allocator);
+    const buffer: [30]u8 = undefined;
+    const s = try dt.toRfc3339(buffer);
+    // "2024-08-12T02:15:25.483Z"
+
+    // or
+    const alloc_buffer = std.heap.wasm_allocator.alloc(u8, 30);
+    defer std.heap.wasm_allocator.free(alloc_buffer);
+    const s = try dt.toRfc3339(alloc_buffer);
+    // "2024-08-12T02:15:25.483Z"
+
+    // or
+    const s = try dt.toRfc3339Alloc(std.heap.wasm_allocator);
     defer std.heap.wasm_allocator.free(s);
     // "2024-08-12T02:15:25.483Z"
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -63,5 +63,10 @@
         //"src",
         //"LICENSE",
         //"README.md",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.md",
     },
 }

--- a/src/test.zig
+++ b/src/test.zig
@@ -29,12 +29,28 @@ test "can use Zig std timestamp millis" {
     try std.testing.expectEqual(@rem(ts, 1000), d.millisecond);
 }
 
-test "datetime equality against known input" {
+test "datetime equality against known input - alloc" {
     const dt = DateTime.fromMillis(SAMPLE_MS);
-    const actual = try dt.toRfc3339(std.testing.allocator);
+    const actual = try dt.toRfc3339Alloc(std.testing.allocator);
     defer std.testing.allocator.free(actual);
 
     try std.testing.expectEqualStrings("2024-08-12T02:15:25.483Z", actual);
+}
+
+test "datetime equality against known input - no alloc" {
+    const dt = DateTime.fromMillis(SAMPLE_MS);
+    var buffer: [30]u8 = undefined;
+    const actual = try dt.toRfc3339(&buffer);
+
+    try std.testing.expectEqualStrings("2024-08-12T02:15:25.483Z", actual);
+}
+
+test "buffer to small" {
+    var buffer: [29]u8 = undefined;
+    const dt = DateTime.fromMillis(SAMPLE_MS);
+    const actual = dt.toRfc3339(&buffer);
+
+    try std.testing.expectEqual(error.BufferTooSmall, actual);
 }
 
 test "serializes to JSON in new struct" {


### PR DESCRIPTION
The two allocations in the original implementation were frankly unacceptable for any performance sensitive code.
The old version is intact and has been renamed to `toRfc3339Alloc` and a new version has been added that allows a library consumer to pass in a buffer that is checked to be large enough. This buffer could be on the stack or the heap, as demonstrated by the examples in the readme.